### PR TITLE
Consertar colisões

### DIFF
--- a/src/Jogo/Models/BlockEntity.cs
+++ b/src/Jogo/Models/BlockEntity.cs
@@ -31,33 +31,17 @@ class BlockEntity : IEntity
 		Raylib.DrawRectangle(x, y, GameSystem.TileSize, GameSystem.TileSize, Color.Violet);
 	}
 
-	public void Collide(LevelScene level, IEntity entity)
-	{
-		if (entity is PlayerEntity)
-		{
-			var idiff = Position.i - entity.Position.i;
-			var jdiff = Position.j - entity.Position.j;
-			GridVec2 delta = GridVec2.ZERO;
-			if (idiff != 0)
-			{
-				delta = new GridVec2(Math.Sign(idiff), 0);
-			}
-			if (jdiff != 0)
-			{
-				delta = new GridVec2(0, Math.Sign(jdiff));
-			}
-			var newPos = Position + delta;
-			if (newPos.i < 0 || newPos.i >= level.Map.Rows)
-				return;
-			if (newPos.j < 0 || newPos.j >= level.Map.Collumns)
-				return;
-			foreach (var another in level.Map[newPos])
-			{
-				another.Collide(level, this);
-			}
-			if (level.Map[newPos].Any(e => !e.CanOverlapWith(level, this)))
-				return;
-			Position = newPos;
+	public bool GetPushed(LevelScene level, IEntity entity, GridVec2 direction) {
+		if(direction.Equals(GridVec2.ZERO)) return false;
+		GridVec2 newPos = Position + direction;
+		if (newPos.i < 0 || newPos.i >= level.Map.Rows) return false;
+		if (newPos.j < 0 || newPos.j >= level.Map.Collumns) return false;
+		if (level.Map[newPos].Any(e => !e.CanOverlapWith(level, this)))
+			return false;
+		Position = newPos;
+		foreach(IEntity e in level.Map[newPos]) {
+			e.Collide(level, this);
 		}
+		return true;
 	}
 }

--- a/src/Jogo/Models/IEntity.cs
+++ b/src/Jogo/Models/IEntity.cs
@@ -32,4 +32,13 @@ interface IEntity
 	/// <param name="level">The level scene where the collision occurred.</param>
 	/// <param name="player">The player entity involved in the collision.</param>
 	void Collide(LevelScene level, IEntity player) { }
+
+	/// <summary>
+	/// Attempts to push the entity in the specified direction.
+	/// </summary>
+	/// <param name="level"></param>
+	/// <param name="entity"></param>
+	/// <param name="direction"></param>
+	/// <returns>True if the entity was pushed, otherwise false.</returns>
+	bool GetPushed(LevelScene level, IEntity entity, GridVec2 direction) { return false; }
 }

--- a/src/Jogo/Systems/PlayerMovementSystem.cs
+++ b/src/Jogo/Systems/PlayerMovementSystem.cs
@@ -31,7 +31,8 @@ class PlayerMovementSystem : ISystem<LevelScene>
 			return;
 		foreach(IEntity entity in level.Map[newPos]) {
 			if(!entity.CanOverlapWith(level, player)) {
-				if(!entity.GetPushed(level, player, delta)) return;
+				if(!entity.GetPushed(level, player, delta))
+					return;
 			}
 		}
 		player.Position = newPos;

--- a/src/Jogo/Systems/PlayerMovementSystem.cs
+++ b/src/Jogo/Systems/PlayerMovementSystem.cs
@@ -29,11 +29,14 @@ class PlayerMovementSystem : ISystem<LevelScene>
 			return;
 		if (newPos.j < 0 || newPos.j >= level.Map.Collumns)
 			return;
+		foreach(IEntity entity in level.Map[newPos]) {
+			if(!entity.CanOverlapWith(level, player)) {
+				if(!entity.GetPushed(level, player, delta)) return;
+			}
+		}
+		player.Position = newPos;
 		foreach(var entity in level.Map[newPos]){
 			entity.Collide(level, player);
 		}
-		if (level.Map[newPos].Any(e => !e.CanOverlapWith(level, player)))
-			return;
-		player.Position = newPos;
 	}
 }


### PR DESCRIPTION
Adiciona método ```bool GetPushed(LevelScene level, IEntity entity, GridVec2 direction)``` à interface IEntity, para ser chamada antes de uma colisão com objetos que não podem ser sobrepostos.
- Retorna verdadeiro se o objeto pode ser movido
- Retorna false se o objeto ficou no mesmo lugar
- Colide com objetos na nova posição

Agora objetos devem chamar a função ```Collide``` após se moverem, para colidir com os objetos que estão sobrepondo.